### PR TITLE
Reset upstream Dockerfile

### DIFF
--- a/docker/wallet/Dockerfile
+++ b/docker/wallet/Dockerfile
@@ -28,7 +28,7 @@ WORKDIR /dist
 RUN cp /build/main .
 
 FROM scratch as dist
-COPY custom_account_setup.cdc ./
+
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /dist/main /
 


### PR DESCRIPTION
This should fix the failing build on `main` - I forgot to reset the original Dockerfile back to how it was on upstream after I created our custom numero.Dockerfile.