### PR TITLE
Use secure cadence emulator in docker compose

### DIFF
--- a/docker-compose.numero.yml
+++ b/docker-compose.numero.yml
@@ -44,7 +44,7 @@ services:
       retries: 10
 
   emulator:
-    image: gcr.io/flow-container-registry/emulator:0.27.3
+    image: gcr.io/flow-container-registry/emulator:0.32.0
     command: emulator --persist
     volumes:
       - emulator-persist:/flowdb


### PR DESCRIPTION
This branch can be used to test the breaking cadence changes locally - it uses the new version of the emulator when starting up docker-compose.